### PR TITLE
Add GitHub Sponsors badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Silverstripe Elemental File List
 
+[![Sponsors](https://img.shields.io/badge/GitHub-Sponsors-ff69b4?logo=github)](https://github.com/sponsors/dynamic)
+
 A multi file block for SilverStripe Elemental.
 
 [![codecov](https://codecov.io/gh/dynamic/silverstripe-elemental-filelist/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-elemental-filelist)


### PR DESCRIPTION
Added GitHub Sponsors badge to README for better visibility. Points to @dynamic organization sponsors page.

This was missing from the previous funding configuration PR #18.