### PR TITLE
feat: Silverstripe 6 compatibility (4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A multi file block for SilverStripe Elemental.
 
 ## Requirements
 
-* Silverstripe ^5.0
-* Silverstripe Elemental ^5.0
+* Silverstripe ^6.0
+* Silverstripe Elemental ^6.0
 
 #### Optional
 

--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,3 @@
 <?php
 
-define('SILVERSTRIPE_ELEMENTAL-FILELIST_PATH', __DIR__);
-define('SILVERSTRIPE_ELEMENTAL-FILELIST_DIR', basename(__DIR__));
+// no-op

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "silverstripe/framework": "^5"
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/framework": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "suggest": {
         "colymba/gridfield-bulk-editing-tools": "Bulk upload files to a list."
@@ -49,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">tests/</directory>
-        </exclude>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="elemental-filelist">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. Major version 4.0 requiring Silverstripe 6 only.

## Changes

- **composer.json**: `elemental ^6`, `framework ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `4.x-dev`
- **phpunit.xml.dist**: Update to PHPUnit 11 format
- **_config.php**: Remove deprecated `define()` constants
- **README.md**: Update requirements to SS6

## Version History

| Version | Silverstripe |
|---------|-------------|
| 4.x     | ^6          |
| 3.x     | ^5          |
| 2.x     | ^4          |
